### PR TITLE
Add streaming OpenAPI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ yarn build:dev
 
 The server runs on [http://localhost:3000](http://localhost:3000) by default. Pass HTML through the `content` query string parameter to render it in the template, for example: `http://localhost:3000/?content=<h1>Hello</h1>`.
 
+## Streaming content from OpenAPI
+
+By default the homepage opens a WebSocket connection and streams HTML generated from the OpenAPI `responses` endpoint for the prompt “render a personal website for James Paterson”. The streamed chunks replace the `{content}` placeholder so the page visibly builds itself as they arrive.
+
+Set the `OPENAPI_API_KEY` environment variable (for example via a `.env` file) before starting the server so it can authenticate with the OpenAPI API.
+
 ## Production build
 
 Create an optimized production bundle:

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "vibe-homepage",
   "packageManager": "yarn@4.9.2",
   "dependencies": {
-    "express": "^5.1.0"
+    "dotenv": "^17.2.2",
+    "express": "^5.1.0",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/node": "^24.5.2",
+    "@types/ws": "^8",
     "concurrently": "^9.2.1",
     "copy-webpack-plugin": "^13.0.1",
     "nodemon": "^3.1.10",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,189 @@
+import dotenv from 'dotenv';
 import express, { Request, Response } from 'express';
 import fs from 'fs';
+import http from 'http';
 import path from 'path';
+import { WebSocketServer, WebSocket } from 'ws';
+
+dotenv.config();
 
 const app = express();
+const server = http.createServer(app);
 
 const rawPort = process.env.PORT ?? '3000';
 const parsedPort = Number.parseInt(rawPort, 10);
 const PORT = Number.isNaN(parsedPort) ? 3000 : parsedPort;
 const TEMPLATE_PATH = path.resolve(__dirname, 'index.html');
-const DEFAULT_CONTENT = [
-  '<h1>Welcome to Vibe Homepage</h1>',
-  '<p>Pass HTML via the <code>content</code> query parameter to customise this page.</p>',
-].join('');
+const STREAM_PROMPT = 'render a personal website for James Paterson';
+const OPENAPI_ENDPOINT = 'https://api.openai.com/v1/responses';
+const OPENAPI_MODEL = 'gpt-4.1-mini';
+
+const DEFAULT_CONTENT = String.raw`
+  <main style="font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 900px; margin: 3rem auto; padding: 0 1.5rem;">
+    <h1 style="margin-bottom: 0.5rem;">Generating James Paterson's personal website</h1>
+    <p id="status" style="color: #555;">Establishing a live connection&hellip;</p>
+    <div id="content" aria-live="polite"></div>
+  </main>
+  <script>
+    (() => {
+      const status = document.getElementById('status');
+      const target = document.getElementById('content');
+      if (!status || !target) {
+        return;
+      }
+
+      const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const socketUrl = protocol + '://' + window.location.host + '/stream';
+      const socket = new WebSocket(socketUrl);
+      let buffer = '';
+
+      const escapeHtml = (value) => value.replace(/[&<>"']/g, (character) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[character] || character);
+
+      socket.addEventListener('open', () => {
+        status.textContent = 'Building the page&hellip;';
+      });
+
+      socket.addEventListener('message', (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          if (payload.type === 'chunk' && typeof payload.data === 'string') {
+            buffer += payload.data;
+            target.innerHTML = buffer;
+            status.textContent = 'Adding sections&hellip;';
+          } else if (payload.type === 'done') {
+            status.textContent = 'James Paterson\'s personal website is ready.';
+            socket.close();
+          } else if (payload.type === 'error' && typeof payload.message === 'string') {
+            status.textContent = 'Unable to build the website.';
+            const errorMarkup = '<pre style="white-space: pre-wrap; background: #f5f5f5; padding: 1rem; border-radius: 0.5rem;">' + escapeHtml(payload.message) + '</pre>';
+            target.innerHTML = errorMarkup;
+            socket.close();
+          }
+        } catch (error) {
+          console.error('Unable to process message', error);
+        }
+      });
+
+      socket.addEventListener('close', () => {
+        if (!buffer) {
+          status.textContent = 'Connection closed before any content was received.';
+        }
+      });
+
+      socket.addEventListener('error', () => {
+        status.textContent = 'A network error occurred.';
+      });
+    })();
+  </script>
+`;
+
+type StreamOptions = {
+  signal?: AbortSignal;
+  onChunk: (chunk: string) => void;
+};
+
+const streamPersonalWebsite = async ({ signal, onChunk }: StreamOptions): Promise<void> => {
+  const apiKey = process.env.OPENAPI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('OPENAPI_API_KEY is not configured. Please add it to your environment.');
+  }
+
+  const response = await fetch(OPENAPI_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: OPENAPI_MODEL,
+      input: STREAM_PROMPT,
+      stream: true,
+    }),
+    signal,
+  });
+
+  if (!response.ok || !response.body) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`OpenAPI request failed with status ${response.status}: ${errorText}`.trim());
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  let completed = false;
+
+  const processBuffer = () => {
+    let newlineIndex: number;
+
+    while ((newlineIndex = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 2);
+
+      const payload = rawEvent
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.replace(/^data:\s*/, ''))
+        .join('\n');
+
+      if (!payload) {
+        continue;
+      }
+
+      if (payload === '[DONE]') {
+        completed = true;
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(payload) as { type?: string; delta?: unknown; error?: { message?: string } };
+
+        if (parsed.type === 'response.output_text.delta' && typeof parsed.delta === 'string') {
+          onChunk(parsed.delta);
+        } else if (parsed.type === 'response.error') {
+          const message = parsed.error?.message ?? 'The OpenAPI service returned an unknown error.';
+          throw new Error(message);
+        }
+      } catch (error) {
+        console.error('Failed to parse streaming payload from OpenAPI', error);
+        throw error instanceof Error ? error : new Error('Failed to parse streaming payload from OpenAPI');
+      }
+    }
+  };
+
+  try {
+    while (!completed) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      processBuffer();
+    }
+
+    if (!completed) {
+      buffer += decoder.decode();
+      processBuffer();
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return;
+    }
+
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+};
 
 const buildPage = (requestedContent?: unknown): string => {
   let template = '';
@@ -41,8 +213,44 @@ app.get('/', (req: Request, res: Response) => {
   res.send(page);
 });
 
-app.listen(PORT, () => {
+const wss = new WebSocketServer({ server, path: '/stream' });
+
+wss.on('connection', (socket: WebSocket) => {
+  const abortController = new AbortController();
+
+  const sendPayload = (payload: Record<string, unknown>) => {
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(payload));
+    }
+  };
+
+  streamPersonalWebsite({
+    signal: abortController.signal,
+    onChunk: (chunk) => {
+      sendPayload({ type: 'chunk', data: chunk });
+    },
+  })
+    .then(() => {
+      sendPayload({ type: 'done' });
+    })
+    .catch((error) => {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : 'Unknown error while contacting OpenAPI.';
+      console.error('OpenAPI streaming failed:', message);
+      sendPayload({ type: 'error', message });
+    });
+
+  socket.on('close', () => {
+    abortController.abort();
+  });
+});
+
+server.listen(PORT, () => {
   console.log(`Server is listening on http://localhost:${PORT}`);
 });
 
+export { app, server };
 export default app;

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ws@npm:^8":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
   version: 1.14.1
   resolution: "@webassemblyjs/ast@npm:1.14.1"
@@ -988,6 +997,13 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.2.2":
+  version: 17.2.2
+  resolution: "dotenv@npm:17.2.2"
+  checksum: 10c0/be66513504590aff6eccb14167625aed9bd42ce80547f4fe5d195860211971a7060949b57108dfaeaf90658f79e40edccd3f233f0a978bff507b5b1565ae162b
   languageName: node
   linkType: hard
 
@@ -2957,8 +2973,10 @@ __metadata:
   dependencies:
     "@types/express": "npm:^5.0.3"
     "@types/node": "npm:^24.5.2"
+    "@types/ws": "npm:^8"
     concurrently: "npm:^9.2.1"
     copy-webpack-plugin: "npm:^13.0.1"
+    dotenv: "npm:^17.2.2"
     express: "npm:^5.1.0"
     nodemon: "npm:^3.1.10"
     ts-loader: "npm:^9.5.4"
@@ -2966,6 +2984,7 @@ __metadata:
     wait-on: "npm:^9.0.0"
     webpack: "npm:^5.101.3"
     webpack-cli: "npm:^6.0.1"
+    ws: "npm:^8.18.3"
   languageName: unknown
   linkType: soft
 
@@ -3135,6 +3154,21 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- load environment variables and stand up a WebSocket server that streams a generated page from the OpenAPI responses endpoint
- update the default page content to connect over WebSockets so the `{content}` placeholder is filled as chunks arrive
- document the required `OPENAPI_API_KEY` variable and add the runtime dependencies

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cd781318f0832eb9ba69fb48ce225a